### PR TITLE
Cache persistente

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ lib-cov
 *.out
 *.pid
 *.gz
+*.lock
 
 pids
 logs
@@ -12,6 +13,7 @@ results
 
 npm-debug.log
 node_modules
+cache/tokens
 
 .DS_Store
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM mhart/alpine-node:7
+RUN mkdir -p /usr/src/afip-api
+WORKDIR /usr/src/afip-api
+COPY package.json /usr/src/afip-api
+RUN apk --update add --virtual compile-deps \
+  g++ gcc libgcc libstdc++ linux-headers make python libressl-dev git && \
+  apk --update add libressl && \
+  npm install --quiet node-gyp -g &&\
+  npm install --quiet && \
+  apk del compile-deps
+COPY . /usr/src/afip-api
+EXPOSE 3000
+CMD ["npm", "run", "dev"]

--- a/cache/index.js
+++ b/cache/index.js
@@ -1,0 +1,27 @@
+const LocalStorage = require('node-localstorage').LocalStorage;
+const ser = require('node-serialize');
+
+class Cache {
+  constructor(name) {
+    this.store = new LocalStorage(`./cache/${name}`);
+  }
+
+  getItem(key) {
+    let obj = this.store.getItem(key);
+    if (obj) {
+      return ser.unserialize(obj);
+    }
+  }
+
+  setItem(key, value) {
+    if (value) {
+      return this.store.setItem(key, ser.serialize(value));
+    }
+  }
+
+  clear() {
+    return this.store.clear();
+  }
+}
+
+module.exports = Cache;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "2"
+services:
+  afip-api:
+    container_name: afip-api
+    restart: always
+    build: .
+    ports:
+      - "3000:3000"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "express": "^4.13.4",
     "lodash": "4.12.0",
     "moment": "^2.13.0",
+    "node-localstorage": "^1.3.1",
+    "node-serialize": "^0.0.4",
     "ntp-client": "^0.5.3",
     "soap": "^0.14.0",
     "xml2js": "^0.4.16"
@@ -17,7 +19,8 @@
   },
   "scripts": {
     "start": "server.js",
-    "debug": "nodemon --inspect=5858 server.js"
+    "debug": "nodemon --inspect=5858 server.js",
+    "dev": "HOMO=true node server.js"
   },
   "devDependencies": {
     "nodemon": "1.14.11"


### PR DESCRIPTION
Usando la API, noté que entre reinicios daba un error de login. Esto se debía a que el cache, donde se suponía que estaban almacenadas las credenciales, era una variable en memoria. Para solucionarlo, agregué un pequeño módulo de cache que permite persistir en disco las credenciales.

Por otro lado, escribí 2 archivos para que se pueda crear un container de docker con la api.