### PR TITLE
Fix expirationTime

### DIFF
--- a/helpers/wsaa.js
+++ b/helpers/wsaa.js
@@ -109,12 +109,8 @@ class Tokens {
 	generateCMS(service) {
 		return new Promise((resolve, reject) => {
 			this.getCurrentTime().then((date) => {
-				var tomorrow = new Date();
-
 				// add a day
-				tomorrow.setDate(date.getDate() + 1);
-
-				tomorrow.setMinutes(date.getMinutes());
+				var tomorrow = moment(date).add(1, 'd')
 
 				var xml = `<?xml version="1.0" encoding="UTF-8" ?><loginTicketRequest version="1.0"><header><uniqueId>{uniqueId}</uniqueId><generationTime>{generationTime}</generationTime><expirationTime>{expirationTime}</expirationTime></header><service>{service}</service></loginTicketRequest>`;
 


### PR DESCRIPTION
La fecha de expiración supera, por algunos milisegundos, las 24 horas y AFIP retorna error.

```
AFIP API Corriendo en el puerto 3000
Current time:  2019-06-11T18:10:39.276Z
expirationTime: 2019-06-12T18:10:42+00:00
{ fault: 
   { faultcode: { _: 'ns1:xml.expirationTime.invalid', header: [Object] },
     faultstring: 'expirationTime posee formato o dato inválido (ej: vencimiento en más de 24 horas)',
     detail: { 'ns2:exceptionname': [Object], 'ns3:hostname': [Object] } } }
```